### PR TITLE
Add support for Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,10 @@
+channels:
+- conda-forge
+dependencies:
+- jupyterlab=0.32.1
+- nodejs=8.9
+- notebook=5.4
+- ipykernel=4.7
+- ipywidgets=7.2
+- widgetsnbextension=3.2
+- python=3.6

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,7 +1,7 @@
 pip install -e .
 
 jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.35.0
-jupyter labextension link .
+jupyter labextension install .
 
 jupyter nbextension install --py --symlink --sys-prefix ipywidgethello 
 jupyter nbextension enable --py --sys-prefix  ipywidgethello

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,7 +1,7 @@
-pip install -e ..
+pip install -e .
 
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
-jupyter labextension link ..
+jupyter labextension link .
 
 jupyter nbextension install --py --symlink --sys-prefix jupyter-widget-hello
 jupyter nbextension enable --py --sys-prefix jupyter-widget-hello

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,6 @@
 pip install -e .
 
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.35.0
 jupyter labextension link .
 
 jupyter nbextension install --py --symlink --sys-prefix jupyter-widget-hello

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,7 @@
+pip install -e ..
+
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+jupyter labextension link ..
+
+jupyter nbextension install --py --symlink --sys-prefix jupyter-widget-hello
+jupyter nbextension enable --py --sys-prefix jupyter-widget-hello

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,5 +3,5 @@ pip install -e .
 jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.35.0
 jupyter labextension link .
 
-jupyter nbextension install --py --symlink --sys-prefix jupyter-widget-hello
-jupyter nbextension enable --py --sys-prefix jupyter-widget-hello
+jupyter nbextension install --py --symlink --sys-prefix ipywidgethello 
+jupyter nbextension enable --py --sys-prefix  ipywidgethello


### PR DESCRIPTION
Add a `binder` folder to be able to test the widget on [Binder](http://mybinder.org/).

Tested with my local fork: https://mybinder.org/v2/gh/jtpio/jupyter-widget-hello/binder

If it looks good and if it makes sense, maybe we can also add it to the cookiecutters?